### PR TITLE
Setup for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  web:
+    image: "nimmis/apache-php7"
+    ports:
+      - "8080:80"
+    volumes:
+      - "./:/var/www/html"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "version": "1.0.0",
     "main": "index.php",
     "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
+      "test": "echo \"Error: no test specified\" && exit 1",
+      "docker": "docker-compose up -d"
     },
     "repository": {
       "type": "git",


### PR DESCRIPTION
This allows us to easily spin up the style guide using [docker](https://www.docker.com/); given that you have it installed on your computer, you can run `npm run docker` and it should do everything you need. It exposes the local style guide on port 8080 (i.e. you visit it at [localhost:8080](http://localhost:8080)