### PR TITLE
bug/notification "Message" typo fixes

### DIFF
--- a/components/Molecules/Notifications.php
+++ b/components/Molecules/Notifications.php
@@ -4,23 +4,23 @@
 <h4>Banner Notifications</h4>
 
 <section class="banner-wrap--primary banner">
-	<div class="banner-wrap__content">Notification Mesage</div>
+	<div class="banner-wrap__content">Notification Message</div>
 	<div class="banner-wrap__dismiss"><i class="fa fa-times"></i></div>
 </section>
 
 <section class="banner-wrap--secondary banner">
-	<div class="banner-wrap__content">Notification Mesage</div>
+	<div class="banner-wrap__content">Notification Message</div>
 	<div class="banner-wrap__dismiss"><i class="fa fa-times"></i></div>
 </section>
 
 <section class="banner-wrap--warning banner">
-	<div class="banner-wrap__content"><i class="icon fa fa-exclamation-circle"> </i> Notification Mesage</div>
+	<div class="banner-wrap__content"><i class="icon fa fa-exclamation-circle"> </i> Notification Message</div>
 	<div class="banner-wrap__dismiss"><i class="fa fa-times"></i></div>
 </section>
 
 
 <section class="banner-wrap--error banner">
-	<div class="banner-wrap__content"><i class="icon fa fa-exclamation-circle"> </i> Error Notification Mesage</div>
+	<div class="banner-wrap__content"><i class="icon fa fa-exclamation-circle"> </i> Error Notification Message</div>
 	<div class="banner-wrap__dismiss"><i class="fa fa-times"></i></div>
 </section>
 
@@ -35,7 +35,7 @@
 <section class="grid grid__three-column demo">
 	<section class="toaster-wrap--primary toaster">
 		<div class="toaster-wrap__content">
-			<p class="content__title">Notification Mesage</p>
+			<p class="content__title">Notification Message</p>
 			<p class="content__message">This is a toaster/popup notification.</p>
 		</div>
 		<div class="toaster-wrap__dismiss"><i class="fa fa-times"></i></div>
@@ -43,7 +43,7 @@
 
 	<section class="toaster-wrap--warning toaster">
 		<div class="toaster-wrap__content">
-			<p class="content__title"><i class="icon fa fa-exclamation-circle"> </i> Notification Mesage</p>
+			<p class="content__title"><i class="icon fa fa-exclamation-circle"> </i> Notification Message</p>
 			<p class="content__message">This is a toaster/popup notification.</p>
 		</div>
 		<div class="toaster-wrap__dismiss"><i class="fa fa-times"></i></div>
@@ -51,7 +51,7 @@
 
 	<section class="toaster-wrap--error toaster">
 		<div class="toaster-wrap__content">
-			<p class="content__title"><i class="icon fa fa-exclamation-circle"> </i> Error Notification Mesage</p>
+			<p class="content__title"><i class="icon fa fa-exclamation-circle"> </i> Error Notification Message</p>
 			<p class="content__message">This is an toaster/popup error notification.</p>
 		</div>
 		<div class="toaster-wrap__dismiss"><i class="fa fa-times"></i></div>


### PR DESCRIPTION
Silly copy and paste error typo, fixed "mesage" to "message" wherever found.