### PR TITLE
Bug/Footer - icon/img Spacing Fix

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -2540,7 +2540,13 @@ footer.solid-footer ul, footer.solid-footer ol,
   .solid-footer ol li {
     padding: 0 1em;
     font-size: 1em; }
-    footer.solid-footer ul li a img.link-icon, footer.solid-footer ol li a img.link-icon,
+    footer.solid-footer ul li a img.link-icon, footer.solid-footer ul li a .link-icon, footer.solid-footer ol li a img.link-icon, footer.solid-footer ol li a .link-icon,
     .solid-footer ul li a img.link-icon,
-    .solid-footer ol li a img.link-icon {
+    .solid-footer ul li a .link-icon,
+    .solid-footer ol li a img.link-icon,
+    .solid-footer ol li a .link-icon {
       margin-right: .5em; }
+footer.solid-footer img.link-icon, footer.solid-footer .link-icon,
+.solid-footer img.link-icon,
+.solid-footer .link-icon {
+  margin-right: .5em; }

--- a/scss/Organisms/_Footers.scss
+++ b/scss/Organisms/_Footers.scss
@@ -29,11 +29,15 @@ footer.solid-footer,
 
 			a {
 
-				img.link-icon {
+				img.link-icon, .link-icon {
 					margin-right: .5em;
 				}
 			}
 		}
+	}
+
+	img.link-icon, .link-icon {
+		margin-right: .5em;
 	}
 }
 


### PR DESCRIPTION
generalized the .link-icon styles for some extended spacing/margin declarations.